### PR TITLE
Feat/add matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,23 @@ https.request.pipe(function (options) {
 });
 
 request('https://www.google.com');
+```
 
+### Usage with domain matchers
+
+In case you want to block just a certain URLs, you can pass an object with request type (`type`) and regex matcher to the `install` method. If matcher is not provided, `fake-http-request` will match all URLs. Request type is optional and it defaults to `https`.
+
+For example, this will fake only requests made to Github URL via HTTPS:
+
+```javascript
+var fakeRequest = require('fake-http-request');
+
+fakeRequest.install({
+  type: 'https',
+  matcher: /github/
+});
+
+// Do something with fake requests
+
+fakeRequest.uninstall('https');
 ```

--- a/index.js
+++ b/index.js
@@ -1,15 +1,20 @@
 /*global require, module */
 var createFakeRequest = require('./src/create-fake-request'),
 	oldRequests = {},
-	installFake = function (type) {
+	installFake = function (options) {
 		'use strict';
-		var target = type || 'https',
-			requestModule = require(target);
+		if (typeof options === 'object' && (options.type || options.matcher)) {
+			var target = options.type || 'https';
+			var matcher = options.matcher;
+		} else {
+			var target = options || 'https';
+		}
+		var requestModule = require(target);
 		if (oldRequests[target]) {
 			throw new Error('Fake HTTP request is already installed in ' + target);
 		}
 		oldRequests[target] = requestModule.request;
-		requestModule.request = createFakeRequest();
+		requestModule.request = createFakeRequest(matcher, oldRequests[target]);
 	},
 	uninstallFake = function (type) {
 		'use strict';

--- a/spec/3rd-party-lib-example-spec.js
+++ b/spec/3rd-party-lib-example-spec.js
@@ -43,10 +43,24 @@ describe('example using a third party library', function () {
 		}).on('response', done.fail);
 	});
 	it('can fake only the requests matched with matcher if provided', function (done) {
-		request('https://www.github.com').on('request', function () {
-			expect(https.request.calls).not.toBeDefined();
-			expect(https.request.pipe).not.toBeDefined();
+		var numOfHttpRequests = https.request.calls.length;
+		request('https://www.github.com', function() {
+			expect(https.request.calls.length).toBe(numOfHttpRequests);
 			done();
 		}).on('error', done.fail);
-	})
+	});
+	it('fakes only the requests it can match', function (done) {
+		request('https://www.google.com', function() {
+			expect(https.request.calls.length).toBe(1);
+			request('https://www.npmjs.com', function () {
+				expect(https.request.calls.length).toBe(1);
+				done();
+			});
+		}).on('request', function () {
+			var numOfHttpRequests = https.request.calls.length
+			numOfHttpRequests &&
+				typeof https.request.calls[numOfHttpRequests - 1].respond === 'function' &&
+				https.request.calls[numOfHttpRequests - 1].respond(200, 'OK', 'Hello there');
+		}).on('error', done.fail);
+	});
 });

--- a/spec/3rd-party-lib-example-spec.js
+++ b/spec/3rd-party-lib-example-spec.js
@@ -5,7 +5,10 @@ var fakeRequest = require('../index'),
 describe('example using a third party library', function () {
 	'use strict';
 	beforeEach(function () {
-		fakeRequest.install('https');
+		fakeRequest.install({
+			type: 'https',
+			matcher: /google/
+		});
 	});
 	afterEach(function () {
 		fakeRequest.uninstall('https');
@@ -39,4 +42,11 @@ describe('example using a third party library', function () {
 			https.request.calls[0].networkError('Boom!');
 		}).on('response', done.fail);
 	});
+	it('can fake only the requests matched with matcher if provided', function (done) {
+		request('https://www.github.com').on('request', function () {
+			expect(https.request.calls).not.toBeDefined();
+			expect(https.request.pipe).not.toBeDefined();
+			done();
+		}).on('error', done.fail);
+	})
 });

--- a/spec/install-spec.js
+++ b/spec/install-spec.js
@@ -27,6 +27,14 @@ describe('index module', function () {
 			expect(originalHttpsRequest).toBe(https.request);
 			fakeRequest.uninstall('http');
 		});
+		it('can receive config as an object', function () {
+			fakeRequest.install({
+				type: 'http'
+			});
+			expect(originalHttpRequest).not.toBe(http.request);
+			expect(originalHttpsRequest).toBe(https.request);
+			fakeRequest.uninstall('http');
+		})
 		it('refuses to install twice', function () {
 			fakeRequest.install();
 			expect(function () {

--- a/src/create-fake-request.js
+++ b/src/create-fake-request.js
@@ -1,11 +1,16 @@
 /*global module, require, setTimeout */
 var FakeCall = require('./fake-call');
 
-module.exports = function createFakeRequest() {
+module.exports = function createFakeRequest(matcher, passthrough) {
 	'use strict';
 	var calls = [],
 		pipes = [],
-		result = function () {
+		result = function (request) {
+			if (matcher && !matcher.test(request.href)) {
+				delete result.calls;
+				delete result.pipe;
+				return passthrough.apply(this, arguments);
+			}
 			var argsArray = [].slice.apply(arguments),
 				listeners = {},
 				bodyBuffer = [],

--- a/src/create-fake-request.js
+++ b/src/create-fake-request.js
@@ -14,6 +14,10 @@ module.exports = function createFakeRequest() {
 						listeners[eventName] = listener;
 						return fake;
 					},
+					once: function (eventName, listener) {
+						listeners[eventName] = listener;
+						return fake;
+					},
 					end: function () {
 						return fake;
 					},

--- a/src/create-fake-request.js
+++ b/src/create-fake-request.js
@@ -7,8 +7,6 @@ module.exports = function createFakeRequest(matcher, passthrough) {
 		pipes = [],
 		result = function (request) {
 			if (matcher && !matcher.test(request.href)) {
-				delete result.calls;
-				delete result.pipe;
 				return passthrough.apply(this, arguments);
 			}
 			var argsArray = [].slice.apply(arguments),

--- a/src/fake-call.js
+++ b/src/fake-call.js
@@ -10,6 +10,9 @@ module.exports = function FakeCall(callArgs, listeners, requestBodyBuffer) {
 			on: function (eventName, listener) {
 				responseListeners[eventName] = listener;
 			},
+			once: function (eventName, listener) {
+				responseListeners[eventName] = listener;
+			},
 			statusCode: statusCode,
 			statusMessage: statusMessage
 		};


### PR DESCRIPTION
Allows `install` method to receive an object with regex matcher. If matcher is provided it will fake only requests to matched URLs.